### PR TITLE
Add optional parameter to set quality for pre defined crops

### DIFF
--- a/Slimsy/Slimsy.cs
+++ b/Slimsy/Slimsy.cs
@@ -166,10 +166,10 @@ namespace Slimsy
             return urlHelper.GetSrcSetUrls(publishedContent, cropAlias, propertyAlias, null);
         }
 
-        public static IHtmlString GetSrcSetUrls(this UrlHelper urlHelper, IPublishedContent publishedContent, string cropAlias, string propertyAlias, string outputFormat)
+        public static IHtmlString GetSrcSetUrls(this UrlHelper urlHelper, IPublishedContent publishedContent, string cropAlias, string propertyAlias, string outputFormat, int quality = 90)
         {
             var w = WidthStep();
-            var q = DefaultQuality();
+            var q = quality == 90 ? DefaultQuality() : quality;
 
             var outputStringBuilder = new StringBuilder();
             var outputString = string.Empty;


### PR DESCRIPTION
The method GetSrcSetUrls that takes in width and height have an optional parameter for the quality.
I was missing the tsame option on the GetSrcSetUrls that takes in a cropalias. So i have added the same option on that method