### PR TITLE
Add support for CDN url and local max width override

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ e.g. An initial image size of 323 x 300. This example is looping people, each pa
 
 This example uses the LQIP (low quality image place holder) technique.
 
-#### `Url.GetSrcSetUrls(publishedContent, int width, int height, int quality)`
+#### `Url.GetSrcSetUrls(publishedContent, int width, int height, int quality, string cdnUrl, int maxWidth)`
 
-#### `Url.GetSrcSetUrls(publishedContent, int width, int height, string propertyAlias)`
+#### `Url.GetSrcSetUrls(publishedContent, int width, int height, string propertyAlias, string cdnUrl, int maxWidth)`
 
-#### `Url.GetSrcSetUrls(publishedContent, int width, int height, string propertyAlias, string outputFormat, int quality)`
+#### `Url.GetSrcSetUrls(publishedContent, int width, int height, string propertyAlias, string outputFormat, int quality, string cdnUrl, int maxWidth)`
 
-#### `Url.GetSrcSetUrls(publishedContent, int width, int height, ImageCropMode? imageCropMode, string outputFormat)`
+#### `Url.GetSrcSetUrls(publishedContent, int width, int height, ImageCropMode? imageCropMode, string outputFormat, string cdnUrl, int maxWidth)`
 
-#### `Url.GetSrcSetUrls(publishedContent, AspectRatio aspectRatio)`
+#### `Url.GetSrcSetUrls(publishedContent, AspectRatio aspectRatio, string cdnUrl, int maxWidth)`
 
 Slimsy v3 allows you to define a predefined ratio for your image so you don't need to work out the math associated with it, first you instantiate a new built in class of AspectRatio and pass in two integer values, this will crop the image(s) to the desired ratio.
 
@@ -103,7 +103,7 @@ Slimsy v3 allows you to define a predefined ratio for your image so you don't ne
 </div>
 ```
 
-#### `Url.GetSrcSetUrls(publishedContent, string cropAlias)`
+#### `Url.GetSrcSetUrls(publishedContent, string cropAlias, string cdnUrl, int maxWidth)`
 Use this method when you want to use a predefined crop, assumes your image cropper property alias is "umbracoFile".
 
 In this example the crop name is "feature"
@@ -121,13 +121,13 @@ In this example the crop name is "feature"
 </div>
 ```
 
-#### `Url.GetSrcSetUrls(publishedContent, string cropAlias, string propertyAlias)`
+#### `Url.GetSrcSetUrls(publishedContent, string cropAlias, string propertyAlias, string cdnUrl, int maxWidth)`
 
-#### `Url.GetSrcSetUrls(publishedContent, string cropAlias, string propertyAlias, string outputFormat)`
+#### `Url.GetSrcSetUrls(publishedContent, string cropAlias, string propertyAlias, string outputFormat, string cdnUrl, int maxWidth)`
 
 ### 4 (optional). Adjust the rendering of your TinyMce Richtext editors
 
-#### `Html.ConvertImgToSrcSet(IPublishedContent publishedContent, string propertyAlias, bool generateLqip)`
+#### `Html.ConvertImgToSrcSet(IPublishedContent publishedContent, string propertyAlias, bool generateLqip, string cdnUrl)`
 
 Use this method to convert images entered into TinyMce Rich Text editors to use img source set using generated paths
 
@@ -136,7 +136,7 @@ Use this method to convert images entered into TinyMce Rich Text editors to use 
 
 ```
 
-#### `Html.ConvertImgToSrcSet(this HtmlHelper htmlHelper, string sourceValueHtml, bool generateLqip)`
+#### `Html.ConvertImgToSrcSet(this HtmlHelper htmlHelper, string sourceValueHtml, bool generateLqip, string cdnUrl)`
 Use this method to convert images entered in a TinyMce Rich Text editor within the Grid to use img source set using generated paths. This method will also take care of parsing Umbraco links and Macros.
 
 e.g. within `Rte.chtml` found within the `Partials/Grid/Editors` folder

--- a/TestSite/App_Code/SlimsyHelper.cshtml
+++ b/TestSite/App_Code/SlimsyHelper.cshtml
@@ -3,7 +3,7 @@
 @using Umbraco.Core
 @using Umbraco.Core.Models.PublishedContent
 @using Umbraco.Web
-@helper RenderPicture(UrlHelper urlHelper, IPublishedContent image, int width, int height, string altText = null)
+@helper RenderPicture(UrlHelper urlHelper, IPublishedContent image, int width, int height, string altText = null, int maxWidth = -1)
 {
     if (image != null)
     {
@@ -36,7 +36,7 @@
         var lqipWidth = (int)Math.Round((decimal)width / 2);
         var lqipHeight = (int)Math.Round((decimal)height / 2);
 
-        var imgSrcSet = urlHelper.GetSrcSetUrls(image, width, height, Constants.Conventions.Media.File, defaultFormat);
+        var imgSrcSet = urlHelper.GetSrcSetUrls(image, width, height, Constants.Conventions.Media.File, defaultFormat, maxWidth);
         var imgSrcSetWebP = urlHelper.GetSrcSetUrls(image, width, height, Constants.Conventions.Media.File, "webp", quality: 70);
 
         var imgSrc = urlHelper.GetCropUrl(image, width, height, furtherOptions: "&format=" + defaultFormat);

--- a/TestSite/Views/people.cshtml
+++ b/TestSite/Views/people.cshtml
@@ -1,12 +1,13 @@
 ﻿@inherits Umbraco.Web.Mvc.UmbracoViewPage<ContentModels.People>
 @using ContentModels = Umbraco.Web.PublishedModels;
 @{
-    Layout = "master.cshtml";
-}
-@helper SocialLink(string content, string service)
-{
-    if (!string.IsNullOrEmpty(content))
+        Layout = "master.cshtml";
+        string cdnUrl = $"{Request.Url.Scheme}://{Request.Url.Host}:{Request.Url.Port}";
+    }
+    @helper SocialLink(string content, string service)
     {
+        if (!string.IsNullOrEmpty(content))
+        {
         <a class="employee-grid__item__contact-item" href="http://@(service).com/@content">@service</a>
     }
 }       
@@ -52,6 +53,61 @@
                 </div>
             }
         </div>
+
+        <h2>Using Image Source Set using Pre Defined Crop and CDN url</h2>
+        <div class="employee-grid">
+            @foreach (ContentModels.Person person in Model.Children)
+            {
+                <div class="employee-grid__item">
+                    <div class="employee-grid__item__image">
+                        <img data-srcset="@Url.GetSrcSetUrls(person.Photo, "feature", cdnUrl: cdnUrl)" data-src="@cdnUrl@Url.GetCropUrl(person.Photo, "feature")" sizes="auto" class="lazyload" />
+
+                    </div>
+                    <div class="employee-grid__item__details">
+                        <h3 class="employee-grid__item__name">@person.Name</h3>
+                        @if (!string.IsNullOrEmpty(person.Email))
+                        {
+                            <a href="mailto:@person.Email" class="employee-grid__item__email">@person.Email</a>
+                        }
+                        <div class="employee-grid__item__contact">
+                            @SocialLink(person.FacebookUsername, "Facebook")
+                            @SocialLink(person.TwitterUsername, "Twitter")
+                            @SocialLink(person.LinkedInUsername, "LinkedIn")
+                            @SocialLink(person.InstagramUsername, "Instagram")
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+
+
+        <h2>Using Image Source Set using Pre Defined Crop with max width override</h2>
+        <p>Images should  be blurry since they are being streched from 160px to 320px</p>
+        <div class="employee-grid">
+            @foreach (ContentModels.Person person in Model.Children)
+            {
+                <div class="employee-grid__item">
+                    <div class="employee-grid__item__image">
+                        <img data-srcset="@Url.GetSrcSetUrls(person.Photo, "feature", cdnUrl: cdnUrl, maxWidth: 160)" data-src="@cdnUrl@Url.GetCropUrl(person.Photo, "feature")" sizes="auto" class="lazyload" />
+
+                    </div>
+                    <div class="employee-grid__item__details">
+                        <h3 class="employee-grid__item__name">@person.Name</h3>
+                        @if (!string.IsNullOrEmpty(person.Email))
+                        {
+                            <a href="mailto:@person.Email" class="employee-grid__item__email">@person.Email</a>
+                        }
+                        <div class="employee-grid__item__contact">
+                            @SocialLink(person.FacebookUsername, "Facebook")
+                            @SocialLink(person.TwitterUsername, "Twitter")
+                            @SocialLink(person.LinkedInUsername, "LinkedIn")
+                            @SocialLink(person.InstagramUsername, "Instagram")
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+
 
         <h2>Using Image Source Set with picture element and WebP ImageProcessor Plugin</h2>
         <div class="employee-grid">
@@ -174,7 +230,7 @@
             {
                 <div class="employee-grid__item">
                     <div class="employee-grid__item__image">
-                        <img src="@Url.GetCropUrl(person.Photo, 323, 0, quality:30, furtherOptions:"&format=auto")" data-srcset="@Url.GetSrcSetUrls(person.Photo, 323, 0)" data-src="@Url.GetCropUrl(person.Photo, 323, 0)" data-sizes="auto" class="lazyload" alt="something really long"/>
+                        <img src="@Url.GetCropUrl(person.Photo, 323, 0, quality:30, furtherOptions:"&format=auto")" data-srcset="@Url.GetSrcSetUrls(person.Photo, 323, 0)" data-src="@Url.GetCropUrl(person.Photo, 323, 0)" data-sizes="auto" class="lazyload" alt="something really long" />
                     </div>
                     <div class="employee-grid__item__details">
                         <h3 class="employee-grid__item__name">@person.Name</h3>


### PR DESCRIPTION
# Issues fixed

## Not able to prefix the image path with a CDN url
On most of our projects we use a CDN for images and with the current version (3.0.0-beta2) it's not possible to prefix the image url. I've added it as an optional parameter to all methods that will just be empty if no value defined. I also added an example on how to do in the test site.

**A little issue that I wasn't able to fix**
When adding a CDN url it looks like it is setting the `src` and `data-src` to the CDN url without the image instead of setting them as empty. I wasn't able to figure out where this is coming from, but maybe you know? It doesn't affect the images, but would be great to have fixed.

## Image widths are set to the screen width
When using Slimsy it automatically lazy loads the images according to screen size which is great for mobile, full width hero images etc. But the a problem occurs when you have am image that is shown in 600px width on a 2560px screen since it will load the image in 2560px width if the media is big enough. I've therefore added a parameter for overriding the web.config max-width on each method call which insures that we only load the 600px on the 2560px screen.

**EDIT:** Sorry just found out that the max-width issue was due to missing `data-sizes="auto"`. On the other hand the max-width override insures that we don't write out unecessary crops in the DOM ;-)

---
**Hope that these features can make it into core** :smiley: