### PR TITLE
Feature/mobile crop alias

### DIFF
--- a/src/Slimsy/Configuration/SlimsyOptions.cs
+++ b/src/Slimsy/Configuration/SlimsyOptions.cs
@@ -15,6 +15,7 @@ namespace Slimsy.Configuration
         public bool EncodeCommas { get; set; } = false;
         public bool AppendSourceDimensions { get; set; } = false;
         public bool AutoOrient { get; set; } = false;
+        public int MobileWidth { get; set; } = 720!;
     }
 
     public sealed class TagHelper

--- a/src/Slimsy/Models/SourceSet.cs
+++ b/src/Slimsy/Models/SourceSet.cs
@@ -7,5 +7,6 @@ namespace Slimsy.Models
         public IHtmlContent? Source { get; set; }
         public IHtmlContent? Lqip { get; set; }
         public string? Format { get; set; }
+        public bool IsMobileSource { get; set; }
     }
 }

--- a/src/Slimsy/Services/SlimsyService.cs
+++ b/src/Slimsy/Services/SlimsyService.cs
@@ -291,10 +291,13 @@ namespace Slimsy.Services
         /// <param name="quality"></param>
         /// <param name="outputFormat"></param>
         /// <param name="furtherOptions"></param>
+        /// <param name="startingWidth"></param>
+        /// <param name="maxWidth"></param>
         /// <returns>Url of image</returns>
-        public IHtmlContent GetSrcSetUrls(MediaWithCrops mediaWithCrops, string cropAlias, string propertyAlias = Constants.Conventions.Media.File, int? quality = null, string? outputFormat = "", string? furtherOptions = "")
+        public IHtmlContent GetSrcSetUrls(MediaWithCrops mediaWithCrops, string cropAlias, string propertyAlias = Constants.Conventions.Media.File, int? quality = null, string? outputFormat = "", string? furtherOptions = "", int startingWidth = 0, int maxWidth = 0)
         {
-            var w = this.WidthStep();
+            var w = startingWidth > 0 ? startingWidth : this.WidthStep();
+            maxWidth = maxWidth > 0 ? maxWidth : this.MaxWidth(mediaWithCrops.Content, ImageCropMode.Crop);
             var q = quality == null ? this.DefaultQuality() : quality;
 
             var outputStringBuilder = new StringBuilder();
@@ -311,7 +314,7 @@ namespace Slimsy.Services
             if (crop != null)
             {
                 var heightRatio = (decimal)crop.Height / crop.Width;
-                while (w <= this.MaxWidth(mediaWithCrops.Content, ImageCropMode.Crop))
+                while (w <= maxWidth)
                 {
                     var h = (int)Math.Round(w * heightRatio);
                     outputStringBuilder.Append(

--- a/src/Slimsy/TagHelpers/SlimsyPictureTagHelper.cs
+++ b/src/Slimsy/TagHelpers/SlimsyPictureTagHelper.cs
@@ -126,12 +126,16 @@ namespace Slimsy
                             imgSrc = _slimsyService.GetCropUrl(MediaItem, cropAlias: CropAlias, useCropDimensions: true, furtherOptions: "&format=" + defaultFormat);
 
                             // Check if mobile crop alias is provided
-                            var mobileCrop = !string.IsNullOrEmpty(MobileCropAlias) ? mergedImageCrops?.Crops?.FirstOrDefault(x => x.Alias.InvariantEquals(MobileCropAlias)) : null;
+                            var mobileCrop = !string.IsNullOrEmpty(MobileCropAlias)
+                                ? mergedImageCrops?.Crops?.FirstOrDefault(x => x.Alias.InvariantEquals(MobileCropAlias))
+                                : null;
+
+                            // setting starting width for desktop sources. This will be adjusted if mobile crop is provided
                             var startingWidth = 0;
 
                             if (mobileCrop != null)
                             {
-                                // Generate mobile sources first (no media attribute - evaluated first/default)
+                                // Generate mobile sources first and set IsMobileSource flag to true
                                 foreach (var source in pictureSources)
                                 {
                                     var mobileSrcSet = _slimsyService.GetSrcSetUrls(MediaItem, MobileCropAlias, PropertyAlias, source.Quality, source.Extension, maxWidth: _slimsyOptions.MobileWidth);
@@ -149,6 +153,7 @@ namespace Slimsy
                                     sources.Add(mobileNativeSource);
                                 }
 
+                                // Set starting width for desktop sources so it doesn't include the mobile widths
                                 startingWidth = _slimsyOptions.MobileWidth + _slimsyOptions.WidthStep;
                             }
 

--- a/src/Slimsy/TagHelpers/SlimsyPictureTagHelper.cs
+++ b/src/Slimsy/TagHelpers/SlimsyPictureTagHelper.cs
@@ -134,7 +134,7 @@ namespace Slimsy
                                 // Generate mobile sources first (no media attribute - evaluated first/default)
                                 foreach (var source in pictureSources)
                                 {
-                                    var mobileSrcSet = _slimsyService.GetSrcSetUrls(MediaItem, MobileCropAlias, PropertyAlias, source.Quality, source.Extension, maxWidth: 720);
+                                    var mobileSrcSet = _slimsyService.GetSrcSetUrls(MediaItem, MobileCropAlias, PropertyAlias, source.Quality, source.Extension, maxWidth: _slimsyOptions.MobileWidth);
                                     imgLqip = _slimsyService.GetCropUrl(MediaItem, lqipWidth, lqipHeight, cropAlias: MobileCropAlias, quality: 20, furtherOptions: "&format=" + source.Extension);
                                     var mobileSource = new SourceSet() { Source = mobileSrcSet, Lqip = imgLqip, Format = source.Extension, IsMobileSource = true };
                                     sources.Add(mobileSource);
@@ -143,13 +143,13 @@ namespace Slimsy
                                 // Handle mobile native format
                                 if (!pictureSources.Select(s => s.Extension).InvariantContains(defaultFormat))
                                 {
-                                    var mobileSrcSetNative = _slimsyService.GetSrcSetUrls(MediaItem, MobileCropAlias, PropertyAlias, outputFormat: defaultFormat, maxWidth: 720);
+                                    var mobileSrcSetNative = _slimsyService.GetSrcSetUrls(MediaItem, MobileCropAlias, PropertyAlias, outputFormat: defaultFormat, maxWidth: _slimsyOptions.MobileWidth);
                                     imgLqip = _slimsyService.GetCropUrl(MediaItem, lqipWidth, lqipHeight, quality: 20, cropAlias: MobileCropAlias, furtherOptions: "&format=" + defaultFormat);
                                     var mobileNativeSource = new SourceSet() { Source = mobileSrcSetNative, Lqip = imgLqip, Format = defaultFormat, IsMobileSource = true };
                                     sources.Add(mobileNativeSource);
                                 }
 
-                                startingWidth = 900;
+                                startingWidth = _slimsyOptions.MobileWidth + _slimsyOptions.WidthStep;
                             }
 
                             foreach (var source in pictureSources)

--- a/src/Slimsy/TagHelpers/SlimsyPictureTagHelper.cs
+++ b/src/Slimsy/TagHelpers/SlimsyPictureTagHelper.cs
@@ -249,7 +249,7 @@ namespace Slimsy
                     foreach (var source in sources)
                     {
                         // Only add media query for mobile sources when mobile crop is provided
-                        var mediaAttribute = source.IsMobileSource ? " media=\"(max-width: 767px)\"" : null;
+                        var mediaAttribute = source.IsMobileSource ? $" media=\"(max-width: {_slimsyOptions.MobileWidth}px)\"" : null;
                         
                         if (Loading == Loading.Lazy)
                         {

--- a/src/Slimsy/TagHelpers/SlimsyPictureTagHelper.cs
+++ b/src/Slimsy/TagHelpers/SlimsyPictureTagHelper.cs
@@ -24,6 +24,10 @@ namespace Slimsy
         /// Crop Alias to use, when this attribute is passed, Width, Height, ImageCropMode & ImageCropAnchor parameters are ignored
         /// </summary>
         public string? CropAlias { get; set; }
+        /// <summary>
+        /// Mobile Crop Alias to use for smaller width variants. When provided, mobile and desktop sources will be generated separately with media queries
+        /// </summary>
+        public string? MobileCropAlias { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
         public string? AltText { get; set; }
@@ -121,9 +125,36 @@ namespace Slimsy
 
                             imgSrc = _slimsyService.GetCropUrl(MediaItem, cropAlias: CropAlias, useCropDimensions: true, furtherOptions: "&format=" + defaultFormat);
 
+                            // Check if mobile crop alias is provided
+                            var mobileCrop = !string.IsNullOrEmpty(MobileCropAlias) ? mergedImageCrops?.Crops?.FirstOrDefault(x => x.Alias.InvariantEquals(MobileCropAlias)) : null;
+                            var startingWidth = 0;
+
+                            if (mobileCrop != null)
+                            {
+                                // Generate mobile sources first (no media attribute - evaluated first/default)
+                                foreach (var source in pictureSources)
+                                {
+                                    var mobileSrcSet = _slimsyService.GetSrcSetUrls(MediaItem, MobileCropAlias, PropertyAlias, source.Quality, source.Extension, maxWidth: 720);
+                                    imgLqip = _slimsyService.GetCropUrl(MediaItem, lqipWidth, lqipHeight, cropAlias: MobileCropAlias, quality: 20, furtherOptions: "&format=" + source.Extension);
+                                    var mobileSource = new SourceSet() { Source = mobileSrcSet, Lqip = imgLqip, Format = source.Extension, IsMobileSource = true };
+                                    sources.Add(mobileSource);
+                                }
+
+                                // Handle mobile native format
+                                if (!pictureSources.Select(s => s.Extension).InvariantContains(defaultFormat))
+                                {
+                                    var mobileSrcSetNative = _slimsyService.GetSrcSetUrls(MediaItem, MobileCropAlias, PropertyAlias, outputFormat: defaultFormat, maxWidth: 720);
+                                    imgLqip = _slimsyService.GetCropUrl(MediaItem, lqipWidth, lqipHeight, quality: 20, cropAlias: MobileCropAlias, furtherOptions: "&format=" + defaultFormat);
+                                    var mobileNativeSource = new SourceSet() { Source = mobileSrcSetNative, Lqip = imgLqip, Format = defaultFormat, IsMobileSource = true };
+                                    sources.Add(mobileNativeSource);
+                                }
+
+                                startingWidth = 900;
+                            }
+
                             foreach (var source in pictureSources)
                             {
-                                imgSrcSet = _slimsyService.GetSrcSetUrls(MediaItem, CropAlias, PropertyAlias, source.Quality, source.Extension);
+                                imgSrcSet = _slimsyService.GetSrcSetUrls(MediaItem, CropAlias, PropertyAlias, source.Quality, source.Extension, startingWidth: startingWidth);
                                 imgLqip = _slimsyService.GetCropUrl(MediaItem, lqipWidth, lqipHeight, cropAlias: CropAlias, quality: 20, furtherOptions: "&format=" + source.Extension);
                                 var newSource = new SourceSet() { Source = imgSrcSet, Lqip = imgLqip, Format = source.Extension };
                                 sources.Add(newSource);
@@ -132,7 +163,7 @@ namespace Slimsy
                             // native format not included in sources so we add it as the last option, it will use the Slimsy default quality
                             if (!pictureSources.Select(s => s.Extension).InvariantContains(defaultFormat))
                             {
-                                imgSrcSet = _slimsyService.GetSrcSetUrls(MediaItem, CropAlias, PropertyAlias, outputFormat: defaultFormat);
+                                imgSrcSet = _slimsyService.GetSrcSetUrls(MediaItem, CropAlias, PropertyAlias, outputFormat: defaultFormat, startingWidth: startingWidth);
                                 // ** Using half width/height for LQIP to reduce filesize to a minimum, CSS must oversize the images **
                                 imgLqip = _slimsyService.GetCropUrl(MediaItem, lqipWidth, lqipHeight, quality: 20, cropAlias: CropAlias, furtherOptions: "&format=" + defaultFormat);
 
@@ -212,25 +243,28 @@ namespace Slimsy
 
                     foreach (var source in sources)
                     {
+                        // Only add media query for mobile sources when mobile crop is provided
+                        var mediaAttribute = source.IsMobileSource ? " media=\"(max-width: 767px)\"" : null;
+                        
                         if (Loading == Loading.Lazy)
                         {
                             if (RenderLQIP)
                             {
                                 htmlContent += Environment.NewLine +
-                                               $@"<source data-srcset=""{source.Source}"" srcset=""{source.Lqip}"" type=""{SlimsyService.MimeType(source.Format)}"" data-sizes=""{sizes}"" />" +
+                                               $@"<source data-srcset=""{source.Source}"" srcset=""{source.Lqip}"" type=""{SlimsyService.MimeType(source.Format)}""{mediaAttribute} data-sizes=""{sizes}"" />" +
                                                Environment.NewLine;
                             }
                             else
                             {
                                 htmlContent += Environment.NewLine +
-                                               $@"<source data-srcset=""{source.Source}"" type=""{SlimsyService.MimeType(source.Format)}"" data-sizes=""{sizes}"" />" +
+                                               $@"<source data-srcset=""{source.Source}"" type=""{SlimsyService.MimeType(source.Format)}""{mediaAttribute} data-sizes=""{sizes}"" />" +
                                                Environment.NewLine;
                             }
                         }
                         else
                         {
                             htmlContent += Environment.NewLine +
-                                           $@"<source srcset=""{source.Source}"" type=""{SlimsyService.MimeType(source.Format)}"" sizes=""{sizes}"" />" +
+                                           $@"<source srcset=""{source.Source}"" type=""{SlimsyService.MimeType(source.Format)}""{mediaAttribute} sizes=""{sizes}"" />" +
                                            Environment.NewLine;
                         }
                     }


### PR DESCRIPTION
### Feature: Added optional "mobile-crop-alias" parameter 

**Background:** 

We have had a few instances where images on mobile are very different compared to their desktop counterpart. Both in crops and shape (example: a small height long width banner image on desktop, but scales to more of a square shape on mobile)

**Idea:** 

It would be good to have a way of setting a separate crop for the mobile image sources, that have can have separate focal points edited in the backoffice

**New logic:**

- For the Slimsy view-component you can now pass in a parameter of "mobile-crop-alias"
- In the tag helper if it detects a mobile crop has been provided then it will add a source to the picture tag for the mobile breakpoints and a separate source for the higher breakpoints
- The breakpoint is set to 720 be default but can be overridden in the Slimsy Options with the "MobileWidth" parameter

⚠️ _This should not break any existing functionality. It merely checks to see if a mobile crop is provided and then adjusts the sources accordingly_